### PR TITLE
`advanced-fields` - Move iframed version to standalone page

### DIFF
--- a/static/advanced-fields/frame.html
+++ b/static/advanced-fields/frame.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<meta charset="utf-8" />
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/water.css@2/out/water.css">
+<title>Advanced fields playground in a frame</title>
+<style>
+	iframe {
+		width: 100%;
+		height: 100vh;
+	}
+</style>
+<h1>Advanced fields playground in a frame</h1>
+<p>
+	🔙 Visit the <a href="./">non-iframed version</a>
+</p>
+<iframe src="./index.html" frameborder="0"></iframe>

--- a/static/advanced-fields/index.html
+++ b/static/advanced-fields/index.html
@@ -3,11 +3,6 @@
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/water.css@2/out/water.css">
 <title>Advanced fields playground</title>
 <style>
-	iframe {
-		width: 100%;
-		height: 100vh;
-	}
-
 	/* Copied from the imported stylesheet to match textarea */
 
 	body>[contenteditable],
@@ -159,7 +154,7 @@
 
 
 	<h2>iframed page</h2>
-	<iframe src="./">
-		There's supposed to be a frame here, but the browser did not load it.
-	</iframe>
+	<p>
+		🎯 Visit the <a href="./frame.html">framed version</a>
+	</p>
 </body>


### PR DESCRIPTION
I think DraftJS is asking for focus from the iframe, so the main page scrolls down to the iframe on load.

This just moves the iframe to its own page to avoid noise and simplify testing.