### PR TITLE
`style-conflicts` - Add `div` and `color-scheme`

### DIFF
--- a/static/style-conflicts/index.html
+++ b/static/style-conflicts/index.html
@@ -26,6 +26,10 @@
 		/* all:initial breaks contenteditable. This restores it */
 		-webkit-user-modify: read-write;
 	}
+	div {
+		overflow-y: scroll;
+		height: 300px;
+	}
 </style>
 <body>
 	<blockquote>
@@ -42,6 +46,13 @@
 	letter-spacing: 1em;
 	color: red;
 }
+div {
+	background-color: darkblue;
+	color-scheme: dark;
+	border: 5px dashed darkolivegreen;
+	border-radius: 3em;
+	width: 4em;
+}
 </style>
 
 	<h1>Test page</h1>
@@ -49,4 +60,15 @@
 	<button>Button</button>
 	<a href="#link">Link</a>
 	<input type="text" value="Input field">
+	<div>
+		<ul>
+			<li>1</li>
+			<li>2</li>
+			<li>3</li>
+			<li>4</li>
+			<li>5</li>
+			<li>6</li>
+			<li>7</li>
+		</ul>
+	</div>
 </body>

--- a/static/style-conflicts/index.html
+++ b/static/style-conflicts/index.html
@@ -53,6 +53,12 @@ div {
 	border-radius: 3em;
 	width: 4em;
 }
+div:not(.local)::-webkit-scrollbar {
+	background-color: fuchsia;
+}
+div:not(.local) {
+	scrollbar-color: red yellow;
+}
 </style>
 
 	<h1>Test page</h1>
@@ -60,7 +66,7 @@ div {
 	<button>Button</button>
 	<a href="#link">Link</a>
 	<input type="text" value="Input field">
-	<div>
+	<div class="local">
 		<ul>
 			<li>1</li>
 			<li>2</li>

--- a/static/style-conflicts/index.html
+++ b/static/style-conflicts/index.html
@@ -33,8 +33,8 @@
 </style>
 <body>
 	<blockquote>
-		Our components might inadvertently inherit some style from the page. This
-		test page has many exaggerated styles to make this leak immediately visible. This description is excluded. The styles are editable:
+		<p>Our components might inadvertently inherit some style from the page. This test page has many exaggerated styles to make this leak immediately visible. This description is excluded. <strong>The solution is usually to set <small><code>all:initial</code></small> at the root of your widget.</strong></p>
+		<p>The styles are editable:</p>
 	</blockquote>
 
 <style contenteditable>html {


### PR DESCRIPTION
https://pixiebrix.slack.com/archives/C023KL47XV4/p1710592528435789?thread_ts=1710519930.124569&channel=C023KL47XV4&message_ts=1710592528.435789

This immediately highlights the conflict on our many empty `div`s:

<img width="529" alt="Screenshot 3" src="https://github.com/pixiebrix/playground/assets/1402241/248d41e1-f8a2-42fe-9b7f-34eb9695a6ce">

