### PR TITLE
`advanced-fields` - Restore DraftJS demo

### DIFF
--- a/static/advanced-fields/index.html
+++ b/static/advanced-fields/index.html
@@ -104,9 +104,9 @@
 	<div class="draftjs">Loading…</div>
 	<link rel="stylesheet" href="https://cdn.skypack.dev/react-draft-wysiwyg/dist/react-draft-wysiwyg.css">
 	<script type="module">
-		import React from 'https://cdn.skypack.dev/react';
-		import ReactDOM from 'https://cdn.skypack.dev/react-dom';
-		import wysiwyg from 'https://esm.sh/react-draft-wysiwyg@1.15.0';
+		import React from "https://esm.sh/react@17.0.2";
+		import ReactDOM from "https://esm.sh/react-dom@17.0.2";
+		import wysiwyg from "https://esm.sh/react-draft-wysiwyg@1.15.0?deps=react@17.0.2,react-dom@17.0.2";
 
 		ReactDOM.render(
 			React.createElement(wysiwyg.Editor, null),


### PR DESCRIPTION
- fixes https://github.com/pixiebrix/pixiebrix-source/issues/637


## Live demo link

https://playground-6ztov1s1w-pixiebrix.vercel.app/advanced-fields/#draftjs



## Screenshot
<img width="647" alt="Screenshot" src="https://github.com/user-attachments/assets/922a0bb6-4a92-4989-86dc-7bbabef192c5" />

