### PR TITLE
`style-conflicts` - Add minimal SVG style

### DIFF
--- a/static/style-conflicts/index.html
+++ b/static/style-conflicts/index.html
@@ -16,7 +16,6 @@
 		border-radius: 3px;
 		padding: 20px;
 	}
-
 	style[contenteditable] {
 		white-space: pre;
 		font-family: monospace;
@@ -59,6 +58,10 @@ div:not(.local)::-webkit-scrollbar {
 }
 div:not(.local) {
 	scrollbar-color: red yellow;
+}
+svg {
+	fill: hotpink;
+	stroke: cyan;
 }
 </style>
 


### PR DESCRIPTION
- https://github.com/pixiebrix/pixiebrix-source/issues/852

It shouldn't apply there, but it thought SVG could be covered too.