### PR TITLE
Add tinymce 6 and tinymce 7 dedicated pages for E2E testing

### DIFF
--- a/static/e2e/license.md
+++ b/static/e2e/license.md
@@ -1,0 +1,3 @@
+# Software License Agreement
+
+Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html) to match TinyMCE's open source license.

--- a/static/e2e/tinymce6.html
+++ b/static/e2e/tinymce6.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<meta charset="utf-8" />
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/water.css@2/out/water.css">
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/tinymce@6.8.5/skins/ui/oxide/content.min.css" integrity="sha256-2O0twlBqGq0T3SxW56BBNI8yK6B9QjAzDQSDTIQ98rU=" crossorigin="anonymous">
+<script src="https://cdn.jsdelivr.net/npm/tinymce@6.8.5/tinymce.min.js" integrity="sha256-yFZrFbtKKJ5Q+buySYOf3fcUbtRMwXrQXAPqHMqNmRo=" crossorigin="anonymous"></script>
+<title>TinyMCE 6</title>
+
+<body>
+	<h1>TinyMCE 6</h1>
+	<p><a href="https://www.npmjs.com/package/tinymce">Docs</a></p>
+	<textarea class="tinymce6">This is an editor</textarea>
+	<script>tinymce.init({ selector: '.tinymce6',  license_key: 'gpl', promotion: false });</script>
+</body>

--- a/static/e2e/tinymce7.html
+++ b/static/e2e/tinymce7.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<meta charset="utf-8" />
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/water.css@2/out/water.css">
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/tinymce@7.7.2/skins/ui/oxide/content.min.css" integrity="sha256-zFNDqXo8CpdM06nXGbQCnwP7j6lht5Q9ZVNcMyfhBVg=" crossorigin="anonymous">
+<script src="https://cdn.jsdelivr.net/npm/tinymce@7.7.2/tinymce.min.js" integrity="sha256-NF8udral0m2v61b8ahSLK41kZfPEWs2Evq6OHKTV2ng=" crossorigin="anonymous"></script>
+<title>TinyMCE 7</title>
+
+<body>
+	<h1>TinyMCE 7</h1>
+	<p><a href="https://www.npmjs.com/package/tinymce">Docs</a></p>
+	<textarea class="tinymce7">This is an editor</textarea>
+	<script>tinymce.init({ selector: '.tinymce7',  license_key: 'gpl', promotion: false });</script>
+</body>


### PR DESCRIPTION
- Closes https://github.com/pixiebrix/pixiebrix-source/issues/1624
- Closes https://github.com/pixiebrix/pixiebrix-source/issues/1501
- Follows https://cdn.jsdelivr.net/npm/tinymce@7.7.2/license.md

Future work:

- https://github.com/pixiebrix/pixiebrix-source/issues/1625