### PR TITLE
`style-conflicts` - Limit conflicts a bit

### DIFF
--- a/static/style-conflicts/index.html
+++ b/static/style-conflicts/index.html
@@ -48,9 +48,10 @@
 	font-style: italic;
 	letter-spacing: 1em;
 	color: red;
-	margin: 200px;
+	margin: 100px;
+	border: solid 1px cyan;
 }
-div:not(#__bs_notify__) {
+div {
 	background-color: darkblue;
 	color-scheme: dark;
 	border: 5px dashed darkolivegreen;


### PR DESCRIPTION
It turns out that fixing these conflicts is difficult.

Actually, fixing them is as easy as adding `!important` to our `all: initial`, but that overrides all inline style as well, which we [use](https://github.com/pixiebrix/pixiebrix-source/blob/81567a39d86462a0805dabc7f3cc00fe1d1f3adb/libs/util-common/src/utils/renderWidget.tsx#L87), so it needs further work.