### PR TITLE
Add E2E automation hooks to trigger-performance harness

### DIFF
--- a/public/trigger-performance/attribute-dedup.html
+++ b/public/trigger-performance/attribute-dedup.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>trigger-performance: attribute dedup</title>
+  <style>
+    body { font-family: system-ui, sans-serif; margin: 0; }
+    #pbx-root { padding: 16px 20px; }
+    .dedup-target {
+      display: inline-block; min-width: 220px; padding: 10px 14px; margin: 4px;
+      background: #e2e8f0; border-radius: 6px; font: 13px monospace; color: #1e293b;
+    }
+    .dedup-target.hot { background: #bbf7d0; }
+  </style>
+</head>
+<body>
+  <script src="vendor/jqi-old.js"></script>
+  <script src="vendor/jqi-new.js"></script>
+  <script src="harness.js"></script>
+  <script>
+    PBX.page({
+      title: "Attribute dedup",
+      intro: `
+        <h1>Attribute dedup (correctness, not perf)</h1>
+        <p>A <strong>single, stable</strong> <code>.dedup-target</code> element whose
+        <em>attributes</em> churn — <code>class</code>, <code>aria-expanded</code>,
+        <code>data-*</code>, <code>style</code> — but which is <strong>never added or
+        removed</strong>. Node identity is constant.</p>
+        <p>This is the deterministic dedup invariant behind issue
+        <strong>#8313</strong>, isolated from any performance stress: a correct
+        <em>button</em> starter brick must inject <strong>exactly one</strong> button
+        (not one per attribute mutation), and a correct <em>trigger</em> must fire
+        <strong>once</strong>, not on every observer callback.</p>
+        <p><strong>For automated tests</strong> load with
+        <code>?harness=off&amp;panel=0&amp;autostart=1&amp;cycles=120</code>: the page
+        flips attributes for exactly 120 ticks, then sets
+        <code>&lt;html data-pbx-workload="done"&gt;</code>. Then assert a single
+        injected button / a single <code>window.PBX.observed</code> fire for
+        <code>data-item="0"</code>.</p>
+        <p>Target selector for a real mod: <code>.dedup-target</code></p>`,
+      selectors: [".dedup-target"],
+      tunables: [
+        { key: "attrs", label: "Attr flips / sec", def: 240, min: 1, max: 8000 },
+      ],
+      build(root, p) {
+        const el = document.createElement("div");
+        el.className = "dedup-target";
+        el.dataset.item = "0"; // the one and only target
+        el.textContent = "single stable target";
+        root.appendChild(el);
+      },
+      start(root, p) {
+        const el = root.querySelector(".dedup-target");
+        const perFrame = Math.max(1, Math.round(p.attrs / 60));
+        let n = 0;
+        PBX.frame(() => {
+          for (let i = 0; i < perFrame; i++) {
+            el.classList.toggle("hot");
+            el.setAttribute("aria-expanded", n & 1 ? "true" : "false");
+            el.setAttribute("data-v", n); // ignored by optimized attributeFilter
+            el.style.opacity = n % 2 ? "0.99" : "1";
+            n++;
+          }
+        });
+      },
+    });
+  </script>
+</body>
+</html>

--- a/public/trigger-performance/detached-subtree.html
+++ b/public/trigger-performance/detached-subtree.html
@@ -44,12 +44,14 @@
       start(root, p) {
         const stage = root.querySelector("#stage");
         const perFrame = Math.max(1, Math.round(p.rate / 60));
+        let n = 0;
         PBX.frame(() => {
           for (let i = 0; i < perFrame; i++) {
             const sub = document.createElement("div");
             for (let j = 0; j < p.size; j++) {
               const c = document.createElement("span");
               c.className = "portal-content";
+              c.dataset.item = n++; // stable identity (each churn cycle is a distinct node)
               c.textContent = ".";
               sub.appendChild(c);
             }

--- a/public/trigger-performance/harness.js
+++ b/public/trigger-performance/harness.js
@@ -31,6 +31,28 @@
  *
  * Every config value lives in the URL query string, so a crashing setup is a
  * shareable link, e.g. mutation-storm.html?harness=legacy&rate=800&nodes=20000
+ *
+ * ---------------------------------------------------------------------------
+ * Automated-testing hooks (for driving these pages with the REAL extension)
+ * ---------------------------------------------------------------------------
+ * Load with `?harness=off&panel=0` to get a clean DOM target (no competing
+ * in-page watcher, no fixed overlay), then:
+ *
+ *   ?cycles=N    run exactly N workload ticks, then stop. On completion the
+ *                harness sets <html data-pbx-workload="done"> and fires a
+ *                `pbx:workload-done` event — await that instead of a timeout.
+ *                Lifecycle: data-pbx-workload = idle -> running -> done.
+ *   ?autostart=1 begin the workload without clicking Start.
+ *
+ * Generated nodes carry a stable identity (data-item / data-row) so a test can
+ * assert per-element behavior. A mod reports work two ways, both tallied on
+ * window.PBX.observed ({ total, counts, keys }):
+ *   - page-world:  window.PBX.record(name, key)
+ *   - isolated:    dispatch a `pbx:record` DOM event on the matched element
+ *                  (its data-item/data-row becomes the key)
+ *
+ * e.g. infinite-scroll-burst.html?harness=off&panel=0&autostart=1&burst=10&cycles=5
+ * appends exactly 50 .feed-row[data-row] nodes, then signals done.
  */
 (function () {
   "use strict";
@@ -48,10 +70,19 @@
   };
 
   let MODE = "optimized"; // off | legacy | optimized
+  let PANEL = true; // render the harness panel? panel=0 hides it (clean DOM target for extension E2E)
+  let CYCLES = 0; // stop after N workload ticks (0 = unbounded); makes runs deterministic for tests
+  let ticks = 0; // workload ticks elapsed in the current run
   const timers = new Set(); // intervals registered via PBX.every / PBX.frame
   const rafs = new Set(); // rAF ids registered via PBX.raf
   let watcherObservers = []; // MutationObservers returned by initialize()
   let activePage = null; // the page def passed to PBX.page()
+
+  // External observations, kept separate from the vendored-watcher `stats.matches`. When you drive
+  // a page with the *real extension* (harness=off), a mod feeds these — either from page-world JS
+  // via window.PBX.record(name, key), or by dispatching a `pbx:record` DOM event on the matched
+  // element (its data-item/data-row supplies the key). Lets a test assert e.g. "fired once per row".
+  const observed = { total: 0, counts: {}, keys: {} };
 
   // ---- tiny URL-param layer -------------------------------------------------
   const search = new URLSearchParams(location.search);
@@ -61,6 +92,24 @@
   function numParam(key, def) {
     const v = Number(rawParam(key));
     return Number.isFinite(v) && rawParam(key) !== null ? v : def;
+  }
+
+  // ---- deterministic run lifecycle (for automated tests) --------------------
+  // Reflected on <html data-pbx-workload> as idle -> running -> done so a test can await quiescence
+  // (expect(html).toHaveAttribute("data-pbx-workload", "done")) instead of guessing with timeouts.
+  function setWorkloadState(state) {
+    document.documentElement.setAttribute("data-pbx-workload", state);
+  }
+  function runSnapshot() {
+    return {
+      mode: MODE,
+      ticks,
+      fps: stats.fps,
+      matches: stats.matches,
+      domNodes: stats.domNodes,
+      observed: { total: observed.total, counts: { ...observed.counts } },
+      elapsedMs: stats.startedAt ? performance.now() - stats.startedAt : 0,
+    };
   }
 
   // =========================================================================
@@ -161,6 +210,7 @@
           <span>Long tasks / sec</span><b id="s-lt">0</b>
           <span>Max task (ms)</span><b id="s-mt">0</b>
           <span>Matches</span><b id="s-match">0</b>
+          <span>Observed (mod)</span><b id="s-obs">0</b>
           <span>DOM nodes</span><b id="s-dom">0</b>
           <span>Elapsed (s)</span><b id="s-elapsed">0</b>
         </div>
@@ -247,6 +297,7 @@
       lt: panel.querySelector("#s-lt"),
       mt: panel.querySelector("#s-mt"),
       match: panel.querySelector("#s-match"),
+      observed: panel.querySelector("#s-obs"),
       dom: panel.querySelector("#s-dom"),
       elapsed: panel.querySelector("#s-elapsed"),
       start: panel.querySelector("#pbx-start"),
@@ -282,8 +333,10 @@
     if (stats.running) return;
     stats.running = true;
     stats.startedAt = performance.now();
-    els.start.disabled = true;
-    els.stop.disabled = false;
+    ticks = 0;
+    setWorkloadState("running");
+    if (els.start) els.start.disabled = true;
+    if (els.stop) els.stop.disabled = false;
     page.start && page.start(page.root, page.params);
   }
 
@@ -295,8 +348,21 @@
     timers.clear();
     rafs.forEach((id) => cancelAnimationFrame(id));
     rafs.clear();
-    els.start.disabled = false;
-    els.stop.disabled = true;
+    if (els.start) els.start.disabled = false;
+    if (els.stop) els.stop.disabled = true;
+  }
+
+  // Bounded runs: when cycles=N is set, stop after N workload ticks and emit the done signal. The
+  // setTimeout(0) lets the final tick's DOM mutations settle (and the watcher observe them) first.
+  function finishRun() {
+    if (!stats.running) return;
+    stopWorkload();
+    PBX.lastRun = runSnapshot();
+    setWorkloadState("done");
+    window.dispatchEvent(new CustomEvent("pbx:workload-done", { detail: PBX.lastRun }));
+  }
+  function countTick() {
+    if (CYCLES > 0 && stats.running && ++ticks >= CYCLES) setTimeout(finishRun, 0);
   }
 
   // ---- long-task observer (main-thread blocking) ----------------------------
@@ -328,6 +394,7 @@
         els.lt.className = stats.longTasks > 0 ? "bad" : "ok";
         els.mt.textContent = stats.maxTaskMs.toFixed(0);
         els.match.textContent = stats.matches.toLocaleString();
+        els.observed.textContent = observed.total.toLocaleString();
         stats.domNodes = els.root ? els.root.getElementsByTagName("*").length : 0;
         els.dom.textContent = stats.domNodes.toLocaleString();
         els.elapsed.textContent = stats.running ? ((now - stats.startedAt) / 1000).toFixed(0) : "0";
@@ -348,7 +415,10 @@
   const PBX = {
     /** Register an interval that Stop() will clear. */
     every(ms, fn) {
-      const id = setInterval(fn, ms);
+      const id = setInterval(() => {
+        fn();
+        countTick();
+      }, ms);
       timers.add(id);
       return id;
     },
@@ -356,7 +426,10 @@
      *  Preferred over raf() for stress workloads: deterministic and unaffected
      *  by frame-production throttling. */
     frame(fn) {
-      const id = setInterval(fn, 16);
+      const id = setInterval(() => {
+        fn();
+        countTick();
+      }, 16);
       timers.add(id);
       return id;
     },
@@ -365,6 +438,7 @@
       const tick = () => {
         if (!stats.running) return;
         fn();
+        countTick();
         const id = requestAnimationFrame(tick);
         rafs.add(id);
       };
@@ -372,10 +446,35 @@
       rafs.add(id);
     },
     stats,
+    observed,
+    /** Snapshot of the last bounded (cycles=N) run; null until one completes. */
+    lastRun: null,
+
+    /** Record an external observation (e.g. a real mod firing). `key` (a node's data-item/data-row)
+     *  lets a test verify per-element counts — i.e. that it fired exactly once per element. */
+    record(name, key) {
+      const n = name || "fired";
+      observed.total++;
+      observed.counts[n] = (observed.counts[n] || 0) + 1;
+      if (key != null) {
+        (observed.keys[n] = observed.keys[n] || {})[key] = (observed.keys[n][key] || 0) + 1;
+      }
+      if (els.observed) els.observed.textContent = observed.total.toLocaleString();
+      return observed.total;
+    },
+    /** Zero the observation counters (call between phases of a test). */
+    reset() {
+      observed.total = 0;
+      observed.counts = {};
+      observed.keys = {};
+      if (els.observed) els.observed.textContent = "0";
+    },
 
     /** Entry point each page calls exactly once. */
     page(def) {
       MODE = rawParam("harness") || "optimized";
+      PANEL = rawParam("panel") !== "0";
+      CYCLES = numParam("cycles", 0);
       const params = {};
       for (const t of def.tunables || []) {
         params[t.key] = t.options ? rawParam(t.key) || t.def : numParam(t.key, t.def);
@@ -384,18 +483,34 @@
 
       const boot = () => {
         activePage = def;
+        setWorkloadState("idle");
+        // Cross-world bridge: a real mod (isolated world) can't reach window.PBX directly, but it can
+        // dispatch a `pbx:record` DOM event on the matched element; record it with that node's key.
+        window.addEventListener(
+          "pbx:record",
+          (event) => {
+            const target = event.target;
+            const key =
+              target && target.getAttribute
+                ? target.getAttribute("data-item") || target.getAttribute("data-row")
+                : null;
+            PBX.record((event.detail && event.detail.name) || "fired", key);
+          },
+          true
+        );
+
         const root = document.createElement("div");
         root.id = "pbx-root";
         document.body.appendChild(root);
         def.root = root;
 
-        if (def.intro) {
+        if (PANEL && def.intro) {
           const intro = document.createElement("div");
           intro.id = "pbx-intro";
           intro.innerHTML = def.intro;
           document.body.insertBefore(intro, root);
         }
-        buildChrome(def);
+        if (PANEL) buildChrome(def);
         def.build && def.build(root, params);
         // Attach the real watcher against the initial DOM (measures attach cost).
         attachWatcher(def);

--- a/public/trigger-performance/index.html
+++ b/public/trigger-performance/index.html
@@ -91,6 +91,12 @@
         <td><code>.wrapper .deep-target</code></td>
         <td class="pr">scan cost<br>(optional)</td>
       </tr>
+      <tr>
+        <td><a href="attribute-dedup.html">attribute-dedup</a></td>
+        <td>One stable node, attributes only churn (never added/removed) — dedup correctness, no perf stress</td>
+        <td><code>.dedup-target</code></td>
+        <td class="pr">#8313<br>one button / one fire</td>
+      </tr>
     </tbody>
   </table>
 
@@ -201,5 +207,27 @@
   <p style="font-size:13px;color:#64748b">Every knob lives in the URL — a crashing
     configuration is a shareable link, e.g.
     <code>mutation-storm.html?harness=legacy&amp;rate=2000&amp;nodes=20000&amp;autostart=1</code>.</p>
+
+  <h2 style="font-size:18px;margin:26px 0 4px">Driving these pages from automated tests</h2>
+  <div class="note">
+    <p style="margin-top:0">To exercise the <strong>real extension</strong> (not the in-page
+      vendored watcher) against a scenario, load it as a clean DOM target and let it run a bounded,
+      self-signalling workload:</p>
+    <ul style="margin:0 0 8px">
+      <li><code>harness=off&amp;panel=0</code> — no competing watcher, no fixed overlay/intro.</li>
+      <li><code>autostart=1</code> — start without clicking; <code>cycles=N</code> — stop after
+        exactly N workload ticks.</li>
+      <li>On completion: <code>&lt;html data-pbx-workload="done"&gt;</code> (lifecycle
+        <code>idle → running → done</code>) plus a <code>pbx:workload-done</code> event. Await that
+        instead of a timeout.</li>
+      <li>Generated nodes carry a stable <code>data-item</code> / <code>data-row</code> identity.</li>
+      <li>A mod reports work — counted on <code>window.PBX.observed</code> (<code>{ total, counts,
+        keys }</code>) — via page-world <code>window.PBX.record(name, key)</code> or by dispatching a
+        <code>pbx:record</code> DOM event on the matched element.</li>
+    </ul>
+    <p style="margin-bottom:0">e.g.
+      <code>infinite-scroll-burst.html?harness=off&amp;panel=0&amp;autostart=1&amp;burst=10&amp;cycles=5</code>
+      appends exactly 50 <code>.feed-row[data-row]</code> nodes, then signals done.</p>
+  </div>
 </body>
 </html>

--- a/public/trigger-performance/infinite-scroll-burst.html
+++ b/public/trigger-performance/infinite-scroll-burst.html
@@ -50,6 +50,7 @@
           for (let i = 0; i < p.burst; i++) {
             const row = document.createElement("div");
             row.className = "feed-row";
+            row.dataset.row = n; // stable identity for "fired once per row" assertions
             row.innerHTML = "<b>#" + n++ + "</b> Lorem ipsum dolor sit amet, consectetur.";
             frag.appendChild(row);
           }

--- a/public/trigger-performance/mutation-storm.html
+++ b/public/trigger-performance/mutation-storm.html
@@ -43,6 +43,7 @@
         for (let i = 0; i < p.nodes; i++) {
           const d = document.createElement("div");
           d.className = "storm-item";
+          d.dataset.item = i; // stable identity for test assertions / mod keying
           d.textContent = i;
           root.appendChild(d);
         }
@@ -65,6 +66,7 @@
               el.remove();
               const d = document.createElement("div");
               d.className = "storm-item";
+              d.dataset.item = n;
               d.textContent = n;
               root.appendChild(d);
             }

--- a/source/trigger-performance/README.md
+++ b/source/trigger-performance/README.md
@@ -7,6 +7,26 @@ which a customer reported made some pages crash.
 
 Build output goes to `public/trigger-performance/` and is served at `/trigger-performance/`.
 
+## Automated testing (driving the real extension)
+
+The harness panel runs the vendored watcher for manual comparison, but the same pages
+double as **clean DOM targets for E2E tests that drive the real extension**. Load a page
+with `?harness=off&panel=0` (no competing watcher, no fixed overlay) plus:
+
+- `autostart=1` — start the workload without clicking; `cycles=N` — stop after exactly
+  N workload ticks.
+- On completion the harness sets `<html data-pbx-workload="done">` (lifecycle
+  `idle → running → done`) and fires a `pbx:workload-done` event — await that instead of a
+  timeout.
+- Generated nodes carry a stable `data-item` / `data-row` identity.
+- A mod reports work — tallied on `window.PBX.observed` (`{ total, counts, keys }`) — either
+  from page-world JS via `window.PBX.record(name, key)`, or by dispatching a `pbx:record` DOM
+  event on the matched element (its `data-item`/`data-row` becomes the key).
+
+`attribute-dedup.html` is a perf-free correctness scenario for the #8313 dedup invariant: a
+single stable node whose attributes churn (never added/removed), so a correct button injects
+exactly one button and a correct trigger fires once.
+
 ## Build
 
 ```bash

--- a/source/trigger-performance/pages/attribute-dedup.html
+++ b/source/trigger-performance/pages/attribute-dedup.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>trigger-performance: attribute dedup</title>
+  <style>
+    body { font-family: system-ui, sans-serif; margin: 0; }
+    #pbx-root { padding: 16px 20px; }
+    .dedup-target {
+      display: inline-block; min-width: 220px; padding: 10px 14px; margin: 4px;
+      background: #e2e8f0; border-radius: 6px; font: 13px monospace; color: #1e293b;
+    }
+    .dedup-target.hot { background: #bbf7d0; }
+  </style>
+</head>
+<body>
+  <script src="vendor/jqi-old.js"></script>
+  <script src="vendor/jqi-new.js"></script>
+  <script src="harness.js"></script>
+  <script>
+    PBX.page({
+      title: "Attribute dedup",
+      intro: `
+        <h1>Attribute dedup (correctness, not perf)</h1>
+        <p>A <strong>single, stable</strong> <code>.dedup-target</code> element whose
+        <em>attributes</em> churn — <code>class</code>, <code>aria-expanded</code>,
+        <code>data-*</code>, <code>style</code> — but which is <strong>never added or
+        removed</strong>. Node identity is constant.</p>
+        <p>This is the deterministic dedup invariant behind issue
+        <strong>#8313</strong>, isolated from any performance stress: a correct
+        <em>button</em> starter brick must inject <strong>exactly one</strong> button
+        (not one per attribute mutation), and a correct <em>trigger</em> must fire
+        <strong>once</strong>, not on every observer callback.</p>
+        <p><strong>For automated tests</strong> load with
+        <code>?harness=off&amp;panel=0&amp;autostart=1&amp;cycles=120</code>: the page
+        flips attributes for exactly 120 ticks, then sets
+        <code>&lt;html data-pbx-workload="done"&gt;</code>. Then assert a single
+        injected button / a single <code>window.PBX.observed</code> fire for
+        <code>data-item="0"</code>.</p>
+        <p>Target selector for a real mod: <code>.dedup-target</code></p>`,
+      selectors: [".dedup-target"],
+      tunables: [
+        { key: "attrs", label: "Attr flips / sec", def: 240, min: 1, max: 8000 },
+      ],
+      build(root, p) {
+        const el = document.createElement("div");
+        el.className = "dedup-target";
+        el.dataset.item = "0"; // the one and only target
+        el.textContent = "single stable target";
+        root.appendChild(el);
+      },
+      start(root, p) {
+        const el = root.querySelector(".dedup-target");
+        const perFrame = Math.max(1, Math.round(p.attrs / 60));
+        let n = 0;
+        PBX.frame(() => {
+          for (let i = 0; i < perFrame; i++) {
+            el.classList.toggle("hot");
+            el.setAttribute("aria-expanded", n & 1 ? "true" : "false");
+            el.setAttribute("data-v", n); // ignored by optimized attributeFilter
+            el.style.opacity = n % 2 ? "0.99" : "1";
+            n++;
+          }
+        });
+      },
+    });
+  </script>
+</body>
+</html>

--- a/source/trigger-performance/pages/detached-subtree.html
+++ b/source/trigger-performance/pages/detached-subtree.html
@@ -44,12 +44,14 @@
       start(root, p) {
         const stage = root.querySelector("#stage");
         const perFrame = Math.max(1, Math.round(p.rate / 60));
+        let n = 0;
         PBX.frame(() => {
           for (let i = 0; i < perFrame; i++) {
             const sub = document.createElement("div");
             for (let j = 0; j < p.size; j++) {
               const c = document.createElement("span");
               c.className = "portal-content";
+              c.dataset.item = n++; // stable identity (each churn cycle is a distinct node)
               c.textContent = ".";
               sub.appendChild(c);
             }

--- a/source/trigger-performance/pages/harness.js
+++ b/source/trigger-performance/pages/harness.js
@@ -31,6 +31,28 @@
  *
  * Every config value lives in the URL query string, so a crashing setup is a
  * shareable link, e.g. mutation-storm.html?harness=legacy&rate=800&nodes=20000
+ *
+ * ---------------------------------------------------------------------------
+ * Automated-testing hooks (for driving these pages with the REAL extension)
+ * ---------------------------------------------------------------------------
+ * Load with `?harness=off&panel=0` to get a clean DOM target (no competing
+ * in-page watcher, no fixed overlay), then:
+ *
+ *   ?cycles=N    run exactly N workload ticks, then stop. On completion the
+ *                harness sets <html data-pbx-workload="done"> and fires a
+ *                `pbx:workload-done` event — await that instead of a timeout.
+ *                Lifecycle: data-pbx-workload = idle -> running -> done.
+ *   ?autostart=1 begin the workload without clicking Start.
+ *
+ * Generated nodes carry a stable identity (data-item / data-row) so a test can
+ * assert per-element behavior. A mod reports work two ways, both tallied on
+ * window.PBX.observed ({ total, counts, keys }):
+ *   - page-world:  window.PBX.record(name, key)
+ *   - isolated:    dispatch a `pbx:record` DOM event on the matched element
+ *                  (its data-item/data-row becomes the key)
+ *
+ * e.g. infinite-scroll-burst.html?harness=off&panel=0&autostart=1&burst=10&cycles=5
+ * appends exactly 50 .feed-row[data-row] nodes, then signals done.
  */
 (function () {
   "use strict";
@@ -48,10 +70,19 @@
   };
 
   let MODE = "optimized"; // off | legacy | optimized
+  let PANEL = true; // render the harness panel? panel=0 hides it (clean DOM target for extension E2E)
+  let CYCLES = 0; // stop after N workload ticks (0 = unbounded); makes runs deterministic for tests
+  let ticks = 0; // workload ticks elapsed in the current run
   const timers = new Set(); // intervals registered via PBX.every / PBX.frame
   const rafs = new Set(); // rAF ids registered via PBX.raf
   let watcherObservers = []; // MutationObservers returned by initialize()
   let activePage = null; // the page def passed to PBX.page()
+
+  // External observations, kept separate from the vendored-watcher `stats.matches`. When you drive
+  // a page with the *real extension* (harness=off), a mod feeds these — either from page-world JS
+  // via window.PBX.record(name, key), or by dispatching a `pbx:record` DOM event on the matched
+  // element (its data-item/data-row supplies the key). Lets a test assert e.g. "fired once per row".
+  const observed = { total: 0, counts: {}, keys: {} };
 
   // ---- tiny URL-param layer -------------------------------------------------
   const search = new URLSearchParams(location.search);
@@ -61,6 +92,24 @@
   function numParam(key, def) {
     const v = Number(rawParam(key));
     return Number.isFinite(v) && rawParam(key) !== null ? v : def;
+  }
+
+  // ---- deterministic run lifecycle (for automated tests) --------------------
+  // Reflected on <html data-pbx-workload> as idle -> running -> done so a test can await quiescence
+  // (expect(html).toHaveAttribute("data-pbx-workload", "done")) instead of guessing with timeouts.
+  function setWorkloadState(state) {
+    document.documentElement.setAttribute("data-pbx-workload", state);
+  }
+  function runSnapshot() {
+    return {
+      mode: MODE,
+      ticks,
+      fps: stats.fps,
+      matches: stats.matches,
+      domNodes: stats.domNodes,
+      observed: { total: observed.total, counts: { ...observed.counts } },
+      elapsedMs: stats.startedAt ? performance.now() - stats.startedAt : 0,
+    };
   }
 
   // =========================================================================
@@ -161,6 +210,7 @@
           <span>Long tasks / sec</span><b id="s-lt">0</b>
           <span>Max task (ms)</span><b id="s-mt">0</b>
           <span>Matches</span><b id="s-match">0</b>
+          <span>Observed (mod)</span><b id="s-obs">0</b>
           <span>DOM nodes</span><b id="s-dom">0</b>
           <span>Elapsed (s)</span><b id="s-elapsed">0</b>
         </div>
@@ -247,6 +297,7 @@
       lt: panel.querySelector("#s-lt"),
       mt: panel.querySelector("#s-mt"),
       match: panel.querySelector("#s-match"),
+      observed: panel.querySelector("#s-obs"),
       dom: panel.querySelector("#s-dom"),
       elapsed: panel.querySelector("#s-elapsed"),
       start: panel.querySelector("#pbx-start"),
@@ -282,8 +333,10 @@
     if (stats.running) return;
     stats.running = true;
     stats.startedAt = performance.now();
-    els.start.disabled = true;
-    els.stop.disabled = false;
+    ticks = 0;
+    setWorkloadState("running");
+    if (els.start) els.start.disabled = true;
+    if (els.stop) els.stop.disabled = false;
     page.start && page.start(page.root, page.params);
   }
 
@@ -295,8 +348,21 @@
     timers.clear();
     rafs.forEach((id) => cancelAnimationFrame(id));
     rafs.clear();
-    els.start.disabled = false;
-    els.stop.disabled = true;
+    if (els.start) els.start.disabled = false;
+    if (els.stop) els.stop.disabled = true;
+  }
+
+  // Bounded runs: when cycles=N is set, stop after N workload ticks and emit the done signal. The
+  // setTimeout(0) lets the final tick's DOM mutations settle (and the watcher observe them) first.
+  function finishRun() {
+    if (!stats.running) return;
+    stopWorkload();
+    PBX.lastRun = runSnapshot();
+    setWorkloadState("done");
+    window.dispatchEvent(new CustomEvent("pbx:workload-done", { detail: PBX.lastRun }));
+  }
+  function countTick() {
+    if (CYCLES > 0 && stats.running && ++ticks >= CYCLES) setTimeout(finishRun, 0);
   }
 
   // ---- long-task observer (main-thread blocking) ----------------------------
@@ -328,6 +394,7 @@
         els.lt.className = stats.longTasks > 0 ? "bad" : "ok";
         els.mt.textContent = stats.maxTaskMs.toFixed(0);
         els.match.textContent = stats.matches.toLocaleString();
+        els.observed.textContent = observed.total.toLocaleString();
         stats.domNodes = els.root ? els.root.getElementsByTagName("*").length : 0;
         els.dom.textContent = stats.domNodes.toLocaleString();
         els.elapsed.textContent = stats.running ? ((now - stats.startedAt) / 1000).toFixed(0) : "0";
@@ -348,7 +415,10 @@
   const PBX = {
     /** Register an interval that Stop() will clear. */
     every(ms, fn) {
-      const id = setInterval(fn, ms);
+      const id = setInterval(() => {
+        fn();
+        countTick();
+      }, ms);
       timers.add(id);
       return id;
     },
@@ -356,7 +426,10 @@
      *  Preferred over raf() for stress workloads: deterministic and unaffected
      *  by frame-production throttling. */
     frame(fn) {
-      const id = setInterval(fn, 16);
+      const id = setInterval(() => {
+        fn();
+        countTick();
+      }, 16);
       timers.add(id);
       return id;
     },
@@ -365,6 +438,7 @@
       const tick = () => {
         if (!stats.running) return;
         fn();
+        countTick();
         const id = requestAnimationFrame(tick);
         rafs.add(id);
       };
@@ -372,10 +446,35 @@
       rafs.add(id);
     },
     stats,
+    observed,
+    /** Snapshot of the last bounded (cycles=N) run; null until one completes. */
+    lastRun: null,
+
+    /** Record an external observation (e.g. a real mod firing). `key` (a node's data-item/data-row)
+     *  lets a test verify per-element counts — i.e. that it fired exactly once per element. */
+    record(name, key) {
+      const n = name || "fired";
+      observed.total++;
+      observed.counts[n] = (observed.counts[n] || 0) + 1;
+      if (key != null) {
+        (observed.keys[n] = observed.keys[n] || {})[key] = (observed.keys[n][key] || 0) + 1;
+      }
+      if (els.observed) els.observed.textContent = observed.total.toLocaleString();
+      return observed.total;
+    },
+    /** Zero the observation counters (call between phases of a test). */
+    reset() {
+      observed.total = 0;
+      observed.counts = {};
+      observed.keys = {};
+      if (els.observed) els.observed.textContent = "0";
+    },
 
     /** Entry point each page calls exactly once. */
     page(def) {
       MODE = rawParam("harness") || "optimized";
+      PANEL = rawParam("panel") !== "0";
+      CYCLES = numParam("cycles", 0);
       const params = {};
       for (const t of def.tunables || []) {
         params[t.key] = t.options ? rawParam(t.key) || t.def : numParam(t.key, t.def);
@@ -384,18 +483,34 @@
 
       const boot = () => {
         activePage = def;
+        setWorkloadState("idle");
+        // Cross-world bridge: a real mod (isolated world) can't reach window.PBX directly, but it can
+        // dispatch a `pbx:record` DOM event on the matched element; record it with that node's key.
+        window.addEventListener(
+          "pbx:record",
+          (event) => {
+            const target = event.target;
+            const key =
+              target && target.getAttribute
+                ? target.getAttribute("data-item") || target.getAttribute("data-row")
+                : null;
+            PBX.record((event.detail && event.detail.name) || "fired", key);
+          },
+          true
+        );
+
         const root = document.createElement("div");
         root.id = "pbx-root";
         document.body.appendChild(root);
         def.root = root;
 
-        if (def.intro) {
+        if (PANEL && def.intro) {
           const intro = document.createElement("div");
           intro.id = "pbx-intro";
           intro.innerHTML = def.intro;
           document.body.insertBefore(intro, root);
         }
-        buildChrome(def);
+        if (PANEL) buildChrome(def);
         def.build && def.build(root, params);
         // Attach the real watcher against the initial DOM (measures attach cost).
         attachWatcher(def);

--- a/source/trigger-performance/pages/index.html
+++ b/source/trigger-performance/pages/index.html
@@ -91,6 +91,12 @@
         <td><code>.wrapper .deep-target</code></td>
         <td class="pr">scan cost<br>(optional)</td>
       </tr>
+      <tr>
+        <td><a href="attribute-dedup.html">attribute-dedup</a></td>
+        <td>One stable node, attributes only churn (never added/removed) — dedup correctness, no perf stress</td>
+        <td><code>.dedup-target</code></td>
+        <td class="pr">#8313<br>one button / one fire</td>
+      </tr>
     </tbody>
   </table>
 
@@ -201,5 +207,27 @@
   <p style="font-size:13px;color:#64748b">Every knob lives in the URL — a crashing
     configuration is a shareable link, e.g.
     <code>mutation-storm.html?harness=legacy&amp;rate=2000&amp;nodes=20000&amp;autostart=1</code>.</p>
+
+  <h2 style="font-size:18px;margin:26px 0 4px">Driving these pages from automated tests</h2>
+  <div class="note">
+    <p style="margin-top:0">To exercise the <strong>real extension</strong> (not the in-page
+      vendored watcher) against a scenario, load it as a clean DOM target and let it run a bounded,
+      self-signalling workload:</p>
+    <ul style="margin:0 0 8px">
+      <li><code>harness=off&amp;panel=0</code> — no competing watcher, no fixed overlay/intro.</li>
+      <li><code>autostart=1</code> — start without clicking; <code>cycles=N</code> — stop after
+        exactly N workload ticks.</li>
+      <li>On completion: <code>&lt;html data-pbx-workload="done"&gt;</code> (lifecycle
+        <code>idle → running → done</code>) plus a <code>pbx:workload-done</code> event. Await that
+        instead of a timeout.</li>
+      <li>Generated nodes carry a stable <code>data-item</code> / <code>data-row</code> identity.</li>
+      <li>A mod reports work — counted on <code>window.PBX.observed</code> (<code>{ total, counts,
+        keys }</code>) — via page-world <code>window.PBX.record(name, key)</code> or by dispatching a
+        <code>pbx:record</code> DOM event on the matched element.</li>
+    </ul>
+    <p style="margin-bottom:0">e.g.
+      <code>infinite-scroll-burst.html?harness=off&amp;panel=0&amp;autostart=1&amp;burst=10&amp;cycles=5</code>
+      appends exactly 50 <code>.feed-row[data-row]</code> nodes, then signals done.</p>
+  </div>
 </body>
 </html>

--- a/source/trigger-performance/pages/infinite-scroll-burst.html
+++ b/source/trigger-performance/pages/infinite-scroll-burst.html
@@ -50,6 +50,7 @@
           for (let i = 0; i < p.burst; i++) {
             const row = document.createElement("div");
             row.className = "feed-row";
+            row.dataset.row = n; // stable identity for "fired once per row" assertions
             row.innerHTML = "<b>#" + n++ + "</b> Lorem ipsum dolor sit amet, consectetur.";
             frag.appendChild(row);
           }

--- a/source/trigger-performance/pages/mutation-storm.html
+++ b/source/trigger-performance/pages/mutation-storm.html
@@ -43,6 +43,7 @@
         for (let i = 0; i < p.nodes; i++) {
           const d = document.createElement("div");
           d.className = "storm-item";
+          d.dataset.item = i; // stable identity for test assertions / mod keying
           d.textContent = i;
           root.appendChild(d);
         }
@@ -65,6 +66,7 @@
               el.remove();
               const d = document.createElement("div");
               d.className = "storm-item";
+              d.dataset.item = n;
               d.textContent = n;
               root.appendChild(d);
             }


### PR DESCRIPTION
## Why

The `trigger-performance` pages were built for a human eyeballing the harness FPS panel — they run the **vendored** `jQueryInitialize` in-page, not the extension. To also use them as targets for **real-extension** E2E tests in `pixiebrix-source/apps/webext-e2e` (the #8313 button/trigger watch-mode work), the pages need to be deterministic and emit machine-readable signals. Today a test would have to guess with `waitForTimeout` and can only infer dedup behavior.

This adds the hooks only; no extension code and no test specs here — those land in `pixiebrix-source`.

## What

All additive and backward compatible (defaults: panel on, `cycles=0`/unbounded — unchanged).

- **Bounded runs** — `cycles=N` stops after exactly N workload ticks, then sets `<html data-pbx-workload>` (`idle → running → done`) and fires a `pbx:workload-done` event. Tests await quiescence instead of timeouts.
- **Clean target** — `panel=0` hides the harness panel + intro; combined with `harness=off` the page is a pure DOM target (no competing in-page watcher, no fixed overlay).
- **Observation API** — `window.PBX.record(name, key)` / `window.PBX.observed` (`{ total, counts, keys }`), plus a `pbx:record` DOM-event bridge so an isolated-world mod can report fires keyed by the matched node's `data-item`/`data-row`.
- **Stable identity** — `data-item` on `.storm-item` / `.portal-content`, `data-row` on `.feed-row`, so a test can assert per-element behavior ("fired once per row").
- **New `attribute-dedup.html`** — a perf-free correctness scenario for the #8313 dedup invariant: one stable node whose attributes churn (never added/removed), so a correct button injects exactly one button and a correct trigger fires once. CI-stable, no stress needed.

`source/` and `public/` are regenerated in parity; README documents the hooks.

## Verified (Playwright, served `public/`)

- `attribute-dedup.html?harness=off&panel=0&autostart=1&cycles=10` → panel/intro hidden, runs 10 ticks, `data-pbx-workload="done"`, single `.dedup-target[data-item="0"]`.
- `infinite-scroll-burst.html?…&burst=10&cycles=5` → exactly 50 `.feed-row` (`data-row` 0–49), `pbx:workload-done` fired.
- Both observation paths tally on `window.PBX.observed` (page-world `record()` + dispatched `pbx:record` event keyed by `data-item`).
- Default load (no params) still renders the panel + intro and the new "Observed (mod)" stat row.

## Example

```
infinite-scroll-burst.html?harness=off&panel=0&autostart=1&burst=10&cycles=5
```
appends exactly 50 `.feed-row[data-row]` nodes, then signals done.

🤖 Generated with [Claude Code](https://claude.com/claude-code)