### PR TITLE
Add ProseMirror to advanced-fields playground

### DIFF
--- a/static/advanced-fields/index.html
+++ b/static/advanced-fields/index.html
@@ -147,6 +147,35 @@
 		new quill2('.quill2', {theme: 'snow'});
 	</script>
 
+	<h2><a id="prosemirror" href="#prosemirror">ProseMirror</a> (<a href="https://prosemirror.net/">Docs</a>)</h2>
+	<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prosemirror-view@1.41.9/style/prosemirror.css">
+	<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prosemirror-menu@1.3.2/style/menu.css">
+	<div class="prosemirror-content" style="display: none">
+		<p>This is an editor</p>
+	</div>
+	<div class="prosemirror"></div>
+	<script type="module">
+		// ProseMirror is split across many packages that each depend on the core
+		// modules. Pin the shared deps so esm.sh resolves a single instance of
+		// each, otherwise the editor throws "Adding different instances of a keyed plugin".
+		const deps = 'prosemirror-model@1.25.9,prosemirror-state@1.4.4,prosemirror-transform@1.12.0,prosemirror-view@1.41.9';
+		const [{ EditorState }, { EditorView }, { DOMParser }, { schema }, { exampleSetup }] = await Promise.all([
+			import(`https://esm.sh/prosemirror-state@1.4.4?deps=${deps}`),
+			import(`https://esm.sh/prosemirror-view@1.41.9?deps=${deps}`),
+			import(`https://esm.sh/prosemirror-model@1.25.9?deps=${deps}`),
+			import(`https://esm.sh/prosemirror-schema-basic@1.2.4?deps=${deps}`),
+			import(`https://esm.sh/prosemirror-example-setup@1.2.3?deps=${deps}`),
+		]);
+
+		const content = document.querySelector('.prosemirror-content');
+		new EditorView(document.querySelector('.prosemirror'), {
+			state: EditorState.create({
+				doc: DOMParser.fromSchema(schema).parse(content),
+				plugins: exampleSetup({ schema }),
+			}),
+		});
+	</script>
+
 	<h2>iframed page</h2>
 	<p>
 		🎯 Visit the <a href="./frame.html">framed version</a>

--- a/static/advanced-fields/index.html
+++ b/static/advanced-fields/index.html
@@ -154,18 +154,31 @@
 		<p>This is an editor</p>
 	</div>
 	<div class="prosemirror"></div>
+	<!--
+		ProseMirror is split across many packages that all share the core
+		prosemirror-model / -state / -transform / -view modules. They must resolve to a
+		SINGLE instance of each, or the editor throws "multiple versions of
+		prosemirror-model were loaded". The import map points every package at one URL
+		per core module, and esm.sh's ?external keeps each package from bundling its own copy.
+	-->
+	<script type="importmap">
+	{
+		"imports": {
+			"prosemirror-model": "https://esm.sh/prosemirror-model@1.25.9",
+			"prosemirror-transform": "https://esm.sh/prosemirror-transform@1.12.0?external=prosemirror-model",
+			"prosemirror-state": "https://esm.sh/prosemirror-state@1.4.4?external=prosemirror-model,prosemirror-transform",
+			"prosemirror-view": "https://esm.sh/prosemirror-view@1.41.9?external=prosemirror-model,prosemirror-state,prosemirror-transform",
+			"prosemirror-schema-basic": "https://esm.sh/prosemirror-schema-basic@1.2.4?external=prosemirror-model",
+			"prosemirror-example-setup": "https://esm.sh/prosemirror-example-setup@1.2.3?external=prosemirror-model,prosemirror-state,prosemirror-transform,prosemirror-view"
+		}
+	}
+	</script>
 	<script type="module">
-		// ProseMirror is split across many packages that each depend on the core
-		// modules. Pin the shared deps so esm.sh resolves a single instance of
-		// each, otherwise the editor throws "Adding different instances of a keyed plugin".
-		const deps = 'prosemirror-model@1.25.9,prosemirror-state@1.4.4,prosemirror-transform@1.12.0,prosemirror-view@1.41.9';
-		const [{ EditorState }, { EditorView }, { DOMParser }, { schema }, { exampleSetup }] = await Promise.all([
-			import(`https://esm.sh/prosemirror-state@1.4.4?deps=${deps}`),
-			import(`https://esm.sh/prosemirror-view@1.41.9?deps=${deps}`),
-			import(`https://esm.sh/prosemirror-model@1.25.9?deps=${deps}`),
-			import(`https://esm.sh/prosemirror-schema-basic@1.2.4?deps=${deps}`),
-			import(`https://esm.sh/prosemirror-example-setup@1.2.3?deps=${deps}`),
-		]);
+		import { EditorState } from "prosemirror-state";
+		import { EditorView } from "prosemirror-view";
+		import { DOMParser } from "prosemirror-model";
+		import { schema } from "prosemirror-schema-basic";
+		import { exampleSetup } from "prosemirror-example-setup";
 
 		const content = document.querySelector('.prosemirror-content');
 		new EditorView(document.querySelector('.prosemirror'), {


### PR DESCRIPTION
Adds a [ProseMirror](https://prosemirror.net/) editor section to the advanced-fields playground, alongside the existing Quill / TinyMCE / CKEditor / DraftJS demos.

## What
- New `## ProseMirror` section using the standard `prosemirror-example-setup` (menu bar, basic schema, history, input rules, etc.), initialized from inline content.
- Loaded entirely from CDN (esm.sh modules + jsDelivr stylesheets), consistent with the other editors on the page — no build step.

## The tricky part: a single prosemirror-model instance
ProseMirror is split across many packages (`-state`, `-view`, `-model`, `-transform`, …) that all share the core modules. If those resolve to *different* instances, the editor throws **"multiple versions of prosemirror-model were loaded"** and never mounts.

esm.sh's `?deps=` pinning was **not** enough — it still handed `prosemirror-schema-basic` a different `prosemirror-model` build than `prosemirror-state`/`example-setup`. The fix is an **import map** that points every package at one URL per core module, with esm.sh's `?external=` so nothing bundles its own copy.

## Testing
Verified locally with headless Chromium (Playwright):
- No console errors.
- The `.ProseMirror` editor mounts with its full toolbar (bold, italic, code, link, insert/type menus, undo/redo, blockquote).
- Typing into the editor works (confirmed text updates).

Also previewable on the PR's Vercel deployment at `/advanced-fields/#prosemirror`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)