### PR TITLE
Fix Quill and ProseMirror legibility in dark mode

### DIFF
--- a/static/advanced-fields/index.html
+++ b/static/advanced-fields/index.html
@@ -33,6 +33,33 @@
     column-width: 300px;
 	}
 
+	/*
+		Quill (snow) and ProseMirror ship light-theme chrome — dark toolbar icons
+		and light borders that vanish against water.css's dark background, leaving
+		transparent toolbars and a half-light/half-dark ProseMirror. Give them a
+		light editor surface so they render as designed and read as editors, like
+		the TinyMCE/CKEditor demos above.
+	*/
+	.ql-toolbar.ql-snow,
+	.ql-container.ql-snow {
+		background: #fff;
+		border-color: #ccc;
+	}
+
+	.ql-editor {
+		color: #1a1a1a;
+	}
+
+	.ql-editor.ql-blank::before {
+		color: rgba(0, 0, 0, 0.6);
+	}
+
+	.prosemirror .ProseMirror {
+		background: #fff;
+		color: #1a1a1a;
+		border: 1px solid #ccc;
+	}
+
 </style>
 
 <body>


### PR DESCRIPTION
## What

In the advanced-fields playground, the **Quill 1**, **Quill 2**, and **ProseMirror** editors were illegible in dark mode (water.css honors `prefers-color-scheme: dark`):

- **Quill (snow)** rendered with a transparent toolbar and its default `#444` SVG icons, so the formatting controls were nearly invisible against the dark page.
- **ProseMirror** rendered half-white (the menubar ships a white background) and half-dark (the editor content area was transparent), looking broken rather than like an editor.

The other WYSIWYG editors on the page (TinyMCE, CKEditor 4/5) bring their own light surfaces and already read fine.

## Fix

Give Quill and ProseMirror a cohesive light editor surface — exactly how they look on a normal light page — so their light-theme chrome renders as designed and they read as proper editors, consistent with the demos above them. Pure CSS, scoped to those editors' classes.

## Verification

Drove Playwright in emulated dark mode against the local static server, before and after:

| Before (dark) | After (dark) |
|---|---|
| Quill toolbars transparent w/ invisible icons; ProseMirror half-white/half-dark | All three render as clean white editor cards with legible dark icons/text |

Also confirmed light mode is unchanged (no regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)