### PR TITLE
Add Wordgard to advanced-fields playground

### DIFF
--- a/static/advanced-fields/index.html
+++ b/static/advanced-fields/index.html
@@ -61,13 +61,14 @@
 	}
 
 	/*
-		Tiptap, Slate, CodeMirror and Trix render onto a nested surface and ship
-		light-theme chrome, so — like Quill and ProseMirror above — give them a
+		Tiptap, Slate, CodeMirror, Wordgard and Trix render onto a nested surface and
+		ship light-theme chrome, so — like Quill and ProseMirror above — give them a
 		light editor surface so they read against water.css's dark background.
 	*/
 	.tiptap-host .ProseMirror,
 	.slate [data-slate-editor],
 	.codemirror .cm-editor,
+	.wordgard wordgard-editor,
 	.trix trix-editor {
 		background: #fff;
 		color: #1a1a1a;
@@ -271,6 +272,10 @@
 		SINGLE instance of each, or the editor throws "multiple versions of
 		prosemirror-model were loaded". The import map points every package at one URL
 		per core module, and esm.sh's ?external keeps each package from bundling its own copy.
+
+		Wordgard (further down) is split the same way and shares this one import map — a
+		document may only have a single import map. Its entries point at jsDelivr's raw
+		dist because esm.sh's rebundling of the split modules breaks config resolution.
 	-->
 	<script type="importmap">
 	{
@@ -280,7 +285,19 @@
 			"prosemirror-state": "https://esm.sh/prosemirror-state@1.4.4?external=prosemirror-model,prosemirror-transform",
 			"prosemirror-view": "https://esm.sh/prosemirror-view@1.41.9?external=prosemirror-model,prosemirror-state,prosemirror-transform",
 			"prosemirror-schema-basic": "https://esm.sh/prosemirror-schema-basic@1.2.4?external=prosemirror-model",
-			"prosemirror-example-setup": "https://esm.sh/prosemirror-example-setup@1.2.3?external=prosemirror-model,prosemirror-state,prosemirror-transform,prosemirror-view"
+			"prosemirror-example-setup": "https://esm.sh/prosemirror-example-setup@1.2.3?external=prosemirror-model,prosemirror-state,prosemirror-transform,prosemirror-view",
+
+			"wordgard/doc": "https://cdn.jsdelivr.net/npm/wordgard@0.1.0/dist/doc.js",
+			"wordgard/types": "https://cdn.jsdelivr.net/npm/wordgard@0.1.0/dist/types.js",
+			"wordgard/state": "https://cdn.jsdelivr.net/npm/wordgard@0.1.0/dist/state.js",
+			"wordgard/command": "https://cdn.jsdelivr.net/npm/wordgard@0.1.0/dist/command.js",
+			"wordgard/phrases": "https://cdn.jsdelivr.net/npm/wordgard@0.1.0/dist/phrases.js",
+			"wordgard/history": "https://cdn.jsdelivr.net/npm/wordgard@0.1.0/dist/history.js",
+			"wordgard/editor": "https://cdn.jsdelivr.net/npm/wordgard@0.1.0/dist/editor.js",
+			"wordgard/schema": "https://cdn.jsdelivr.net/npm/wordgard@0.1.0/dist/schema.js",
+			"style-mod": "https://esm.sh/style-mod@4.1.3",
+			"@marijn/find-cluster-break": "https://esm.sh/@marijn/find-cluster-break@1.0.2",
+			"crelt": "https://esm.sh/crelt@1.0.6"
 		}
 	}
 	</script>
@@ -373,6 +390,29 @@
 			}
 
 			createRoot(document.querySelector('.slate')).render(h(App));
+		})();
+	</script>
+
+	<h2><a id="wordgard" href="#wordgard">Wordgard</a> (<a href="https://wordgard.net/">Docs</a>)</h2>
+	<div class="wordgard"></div>
+	<script type="module">
+		// Lazy-loaded — see the Lexical block above (pixiebrix/pixiebrix-source#8620).
+		//
+		// Wordgard is the ProseMirror author's newer editor, split the same way into
+		// modules (wordgard/editor, /schema, /history) that share one copy of the core
+		// (wordgard/state, /doc, …). They resolve through the ProseMirror import map
+		// above — inert JSON that doesn't block `load` — which points at jsDelivr's raw
+		// dist because esm.sh's rebundling of the split modules breaks config resolution.
+		// Wordgard injects its own CSS-in-JS, so no stylesheet is needed.
+		void (async () => {
+			const { Wordgard, menuBar } = await import('wordgard/editor');
+			const { basicSchema, orderedList } = await import('wordgard/schema');
+			const { history } = await import('wordgard/history');
+			Wordgard.create({
+				parent: document.querySelector('.wordgard'),
+				doc: `<p>This is an editor</p>`,
+				config: [basicSchema(), orderedList(), history(), menuBar()],
+			});
 		})();
 	</script>
 


### PR DESCRIPTION
Adds **Wordgard** 0.1.0 — the ProseMirror author's newer rich-text editor — to the advanced-fields playground, alongside the existing editors.

## Changes
- New **Wordgard** section, lazy-loaded via dynamic `import()` inside the section script so it doesn't block the page `load` event the e2e suite depends on.
- Wordgard's modules added to the ProseMirror import map. Both editors are split into packages that must resolve to a single core instance, and a document may only have one import map, so they share it. The map points at **jsDelivr's raw dist** because esm.sh's rebundling of the split modules breaks editor config resolution.
- Wordgard folded into the shared nested-surface light-editor CSS rule so it stays legible against water.css's dark background.

Wordgard injects its own CSS via a CSS-in-JS system, so no stylesheet is needed.

## Verification
Rendered in headless Chromium:
- Wordgard mounts (toolbar + editable content) and accepts typed input.
- `load` event fires at ~1.1s; the lazy-loaded editor does not block it.
- No regressions: ProseMirror, Lexical, Tiptap, Slate, and CodeMirror all still mount.
- No new console errors (only the pre-existing CKEditor 4 security notice).

🤖 Generated with [Claude Code](https://claude.com/claude-code)